### PR TITLE
Modify：移除@if~@endif之间所有element，而非paragraph

### DIFF
--- a/src/MiniWord/MiniWord.Implment.cs
+++ b/src/MiniWord/MiniWord.Implment.cs
@@ -510,6 +510,7 @@ namespace MiniSoftware
 
         private static void ReplaceStatements(OpenXmlElement xmlElement, Dictionary<string, object> tags)
         {
+            var descendants = xmlElement.Descendants().ToList();
             var paragraphs = xmlElement.Descendants<Paragraph>().ToList();
 
             while (paragraphs.Any(s => s.InnerText.Contains("@if")))
@@ -525,10 +526,14 @@ namespace MiniSoftware
 
                 if (!checkStatement)
                 {
-                    for (int i = ifIndex + 1; i <= endIfFinalIndex - 1; i++)
+                    var paragraphIfIndex = descendants.FindIndex(a => a == paragraphs[ifIndex]);
+                    var paragraphEndIfIndex = descendants.FindIndex(a => a == paragraphs[endIfFinalIndex]);
+
+                    for (int i = paragraphIfIndex + 1; i <= paragraphEndIfIndex - 1; i++)
                     {
-                        paragraphs[i].Remove();
+                        descendants[i].Remove();
                     }
+
                 }
 
                 paragraphs[ifIndex].Remove();


### PR DESCRIPTION
当@if -- @endif 之间有表格模板时，会存在一个空表格。
如下图，当count=0时，显示了“暂无数据”（预期），和count!=0时的表格（非预期）

![{)_A~ZA~UFFJ{ 0KD58OPPT](https://github.com/user-attachments/assets/66411551-e2d5-442b-8b6e-8457bfac0501)

