### PR TITLE
扩展了2个功能

### DIFF
--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -273,6 +273,39 @@ MiniWord.SaveAsByTemplate(path, templatePath, value);
 
 ![after_if](https://user-images.githubusercontent.com/38832863/220125435-72ea24b4-2412-45de-961a-ad4b2134417b.PNG)
 
+### 循环
+
+ `@foreach` 和 `@endforeach` tags .
+
+##### Example
+
+```csharp
+var value = new  
+{
+    LoopData = new List<object>()
+    {
+        new {
+            Type="类型A",
+            Items = new List<object>() {new {Name = "A-1"}, new {Name = "A-2"},}
+        },
+        new
+        {
+            Type="类型B",
+            Items = new List<object>() {new {Name = "B-1"}, new {Name = "B-2"}, new {Name = "B-3"},}
+        },
+    }
+};
+MiniWord.SaveAsByTemplate(path, templatePath, value);
+```
+
+##### Template
+
+![1](https://github.com/user-attachments/assets/5d32241d-3977-46e7-b3de-cae130e5a653)
+
+##### Result
+
+![2](https://github.com/user-attachments/assets/69daa15e-4864-483e-b132-d8e867b6d1d1)
+
 ### 多彩字体
 
 ##### 代码例子

--- a/src/MiniWord/MiniWord.Implment.cs
+++ b/src/MiniWord/MiniWord.Implment.cs
@@ -672,7 +672,7 @@
                     for (var i = 0; i < list.Count; i++)
                     {
                         var item = list[i];
-                        var foreachDataDict = item.Obj2Dictionary();
+                        var foreachDataDict = item.ToDictionary();
                         // 2. 渲染替换属性值{{}}，插入循环元素，再替换……
                         // 2.1 替换属性值
                         if (i == 0)
@@ -709,34 +709,7 @@
             
             
         }
-
-        /// <summary>
-        /// 将实体对象转为字典格式
-        /// </summary>
-        /// <param name="obj"></param>
-        /// <returns></returns>
-        private static Dictionary<string, object> Obj2Dictionary(this object obj)
-        {
-            var result = new Dictionary<string, object>();
-            if(obj == null) return null;
-            if (obj is IDictionary d)
-            {
-                foreach (object key in d.Keys)
-                {
-                    result.Add(key.ToString(), d[key]);
-                }
-            }
-            else
-            {
-                var props = obj.GetType().GetProperties();
-                foreach (var p in props)
-                {
-                    result.Add(p.Name,p.GetValue(obj));
-                }
-            }
-            return result;
-        }
-
+        
         /// <summary>
         /// 获取关键词之间的元素
         /// </summary>

--- a/src/MiniWord/MiniWord.Implment.cs
+++ b/src/MiniWord/MiniWord.Implment.cs
@@ -445,16 +445,16 @@
                                 var key = isFullMatch ? tag.Key : partMatch.Groups[1].Value;
                                 var value = isFullMatch ? tag.Value : GetObjVal(tags, key);
 
-                                if (tag.Value is string[] || tag.Value is IList<string> || tag.Value is List<string>)
+                                if (value is string[] || value is IList<string> || value is List<string>)
                                 {
-                                    var vs = tag.Value as IEnumerable;
+                                    var vs = value as IEnumerable;
                                     var currentT = t;
                                     var isFirst = true;
                                     foreach (var v in vs)
                                     {
                                         var newT = t.CloneNode(true) as Text;
                                         // todo
-                                        newT.Text = t.Text.Replace($"{{{{{tag.Key}}}}}", v?.ToString());
+                                        newT.Text = t.Text.Replace($"{{{{{key}}}}}", v?.ToString());
                                         if (isFirst)
                                             isFirst = false;
                                         else
@@ -465,7 +465,8 @@
                                     }
                                     t.Remove();
                                 }
-                                else if (tag.Value is List<MiniWordForeach> vs)
+                                // todo 未验证嵌套对象的渲染
+                                else if (value is List<MiniWordForeach> vs)
                                 {
                                     var currentT = t;
                                     var generatedText = new Text();
@@ -478,6 +479,7 @@
 
                                         foreach (var vv in vs[i].Value)
                                         {
+                                            // todo tag,Key
                                             newT.Text = newT.Text.Replace("{{" + tag.Key + "." + vv.Key + "}}", vv.Value.ToString());
                                         }
 
@@ -501,20 +503,20 @@
                                     run.Append(generatedText);
                                     t.Remove();
                                 }
-                                else if (IsHyperLink(tag.Value))
+                                else if (IsHyperLink(value))
                                 {
-                                    AddHyperLink(docx, run, tag.Value);
+                                    AddHyperLink(docx, run, value);
                                     t.Remove();
                                 }
-                                else if (tag.Value is MiniWordColorText || tag.Value is MiniWordColorText[])
+                                else if (value is MiniWordColorText || value is MiniWordColorText[])
                                 {
-                                    if (tag.Value is MiniWordColorText)
+                                    if (value is MiniWordColorText)
                                     {
-                                        AddColorText(run, new[] { (MiniWordColorText)tag.Value });
+                                        AddColorText(run, new[] { (MiniWordColorText)value });
                                     }
                                     else
                                     {
-                                        AddColorText(run, (MiniWordColorText[])tag.Value);
+                                        AddColorText(run, (MiniWordColorText[])value);
                                     }
                                     t.Remove();
                                 }
@@ -544,7 +546,7 @@
                                 }
                                 else
                                 {
-                                    var newText = tag.Value is DateTime ? ((DateTime)value).ToString("yyyy-MM-dd HH:mm:ss") : value?.ToString();
+                                    var newText = value is DateTime ? ((DateTime)value).ToString("yyyy-MM-dd HH:mm:ss") : value?.ToString();
                                     t.Text = t.Text.Replace($"{{{{{key}}}}}", newText);
                                 }
                             }

--- a/src/MiniWord/MiniWord.Implment.cs
+++ b/src/MiniWord/MiniWord.Implment.cs
@@ -795,12 +795,13 @@
 
                     for (int i = paragraphIfIndex + 1; i <= paragraphEndIfIndex - 1; i++)
                     {
-                        rootXmlElement.RemoveChild(elementList[i]);
+                        if(rootXmlElement.ChildElements.Any(c=>c == elementList[i])) rootXmlElement.RemoveChild(elementList[i]);
                     }
                 }
-
-                rootXmlElement.RemoveChild(ifP);
-                rootXmlElement.RemoveChild(endIfP);
+                if(rootXmlElement.ChildElements.Any(c => c == ifP))
+                    rootXmlElement.RemoveChild(ifP);
+                if (rootXmlElement.ChildElements.Any(c => c == endIfP))
+                    rootXmlElement.RemoveChild(endIfP);
                 paragraphs.Remove(ifP);
                 paragraphs.Remove(endIfP);
             }

--- a/src/MiniWord/MiniWord.Implment.cs
+++ b/src/MiniWord/MiniWord.Implment.cs
@@ -124,7 +124,7 @@
                                 foreach (var e in es)
                                 {
                                     var dicKey = $"{listLevelKeys[0]}.{e.Key}";
-                                    dic.Add(dicKey, e.Value);
+                                    dic[dicKey] = e.Value;
                                 }
                             }
                             // 支持Obj.A.B.C...
@@ -134,7 +134,7 @@
                                 foreach (var p in props)
                                 {
                                     var dicKey = $"{listLevelKeys[0]}.{p.Name}";
-                                    dic.Add(dicKey, p.GetValue(item));
+                                    dic[dicKey] = p.GetValue(item);
                                 }
                             }
 
@@ -156,13 +156,24 @@
                     }
                     else
                     {
-                        
+                        var dic = new Dictionary<string, object>(); //TODO: optimize
+
+                        var props = tagObj.GetType().GetProperties();
+                        foreach (var p in props)
+                        {
+                            var dicKey = $"{listLevelKeys[0]}.{p.Name}";
+                            dic[dicKey] = p.GetValue(tagObj);
+                        }
+
+                        ReplaceIfStatements(tr, tags: tagObj.ToDictionary());
+
+                        ReplaceText(tr, docx, tags: dic);
                     }
                 }
                 else
                 {
                     var matchTxtProp = new Regex(@"(?<={{).*?\.?.*?(?=}})").Match(innerText);
-                    if(!matchTxtProp.Success) return;
+                    if(!matchTxtProp.Success) continue;
 
                     ReplaceText(tr, docx, tags);
                 }

--- a/src/MiniWord/MiniWord.Implment.cs
+++ b/src/MiniWord/MiniWord.Implment.cs
@@ -666,7 +666,8 @@
                 var copyLoopEles = betweenEles.Select(e => e.CloneNode(true)).ToList();
                 // 需要循环的数据
                 var foreachList = GetObjVal(data, foreachDataKey);
-                if (foreachList is IList list)
+
+                if (foreachList is IList list && list.Count > 0)
                 {
                     var loopEles = new List<OpenXmlElement>();
                     for (var i = 0; i < list.Count; i++)
@@ -701,6 +702,14 @@
                                 loopEles.Add(newEle);
                             }
                         }
+                    }
+                }
+                else
+                {
+                    // 如果没有数据，删除循环元素
+                    foreach (var ele in betweenEles)
+                    {
+                        ele.Remove();
                     }
                 }
 

--- a/src/MiniWord/MiniWord.Implment.cs
+++ b/src/MiniWord/MiniWord.Implment.cs
@@ -15,6 +15,8 @@
     using A = DocumentFormat.OpenXml.Drawing;
     using DW = DocumentFormat.OpenXml.Drawing.Wordprocessing;
     using PIC = DocumentFormat.OpenXml.Drawing.Pictures;
+    using System.Xml;
+    using System.Xml.Linq;
 
     public static partial class MiniWord
     {
@@ -48,94 +50,122 @@
             // avoid {{tag}} like <t>aa{</t><t>{</t>  test in...
             AvoidSplitTagText(xmlElement);
 
+            // @foreach循环体
+            ReplaceForeachStatements(xmlElement,docx,tags);
+
             //Tables
-            var tables = xmlElement.Descendants<Table>().ToArray();
+            // 忽略table中没有占位符“{{}}”的表格
+            var tables = xmlElement.Descendants<Table>().Where(t => t.InnerText.Contains("{{")).ToArray();
             {
                 foreach (var table in tables)
                 {
-                    var trs = table.Descendants<TableRow>().ToArray(); // remember toarray or system will loop OOM;
-
-                    foreach (var tr in trs)
-                    {
-                        var innerText = tr.InnerText.Replace("{{foreach", "").Replace("endforeach}}", "")
-                            .Replace("{{if(", "").Replace(")if", "").Replace("endif}}", "");
-                        var matchs = (Regex.Matches(innerText, "(?<={{).*?\\..*?(?=}})")
-                            .Cast<Match>().GroupBy(x => x.Value).Select(varGroup => varGroup.First().Value)).ToArray();
-                        if (matchs.Length > 0)
-                        {
-                            //var listKeys = matchs.Select(s => s.Split('.')[0]).Distinct().ToArray();
-                            //// TODO:
-                            //// not support > 2 list in same tr
-                            //if (listKeys.Length > 2)
-                            //    throw new NotSupportedException("MiniWord doesn't support more than 2 list in same row");
-                            //var listKey = listKeys[0];
-
-                            var listLevelKeys = matchs.Select(s => s.Substring(0, s.LastIndexOf('.'))).Distinct().ToArray();
-                            // TODO:
-                            // not support > 2 list in same tr
-                            if (listLevelKeys.Length > 2)
-                                throw new NotSupportedException("MiniWord doesn't support more than 2 list in same row");
-
-                            var tagObj = GetObjVal(tags, listLevelKeys[0]);
-
-                            if (tagObj != null && tagObj is IEnumerable)
-                            {
-                                var attributeKey = matchs[0].Split('.')[0];
-                                var list = tagObj as IEnumerable;
-
-                                foreach (var item in list)
-                                {
-                                    var dic = new Dictionary<string, object>(); //TODO: optimize
-
-
-                                    var newTr = tr.CloneNode(true);
-                                    if (item is IDictionary)
-                                    {
-                                        var es = (Dictionary<string, object>) item;
-                                        foreach (var e in es)
-                                        {
-                                            var dicKey = $"{listLevelKeys[0]}.{e.Key}";
-                                            dic.Add(dicKey, e.Value);
-                                        }
-                                    }
-                                    // 支持Obj.A.B.C...
-                                    else
-                                    {
-                                        var props = item.GetType().GetProperties();
-                                        foreach (var p in props)
-                                        {
-                                            var dicKey = $"{listLevelKeys[0]}.{p.Name}";
-                                            dic.Add(dicKey, p.GetValue(item));
-                                        }
-                                    }
-
-
-                                    
-
-                                    ReplaceStatements(newTr, tags: dic);
-
-                                    ReplaceText(newTr, docx, tags: dic);
-                                    //Fix #47 The table should be inserted at the template tag position instead of the last row
-                                    if (table.Contains(tr))
-                                    {
-                                        table.InsertBefore(newTr, tr);
-                                    }
-                                    else
-                                    {
-                                        // If it is a nested table, temporarily append it to the end according to the original plan.
-                                        table.Append(newTr);
-                                    }
-                                }
-                                tr.Remove();
-                            }
-                        }
-                    }
+                    GenerateTable(table,docx,tags);
                 }
             }
 
-            ReplaceStatements(xmlElement, tags);
+            ReplaceIfStatements(xmlElement, tags);
 
             ReplaceText(xmlElement, docx, tags);
+        }
+
+        /// <summary>
+        /// 渲染Table
+        /// </summary>
+        /// <param name="table"></param>
+        /// <param name="docx"></param>
+        /// <param name="tags"></param>
+        /// <exception cref="NotSupportedException"></exception>
+        private static void GenerateTable(Table table, WordprocessingDocument docx, Dictionary<string, object> tags)
+        {
+            var trs = table.Descendants<TableRow>().ToArray(); // remember toarray or system will loop OOM;
+
+            foreach (var tr in trs)
+            {
+                var innerText = tr.InnerText.Replace("{{foreach", "").Replace("endforeach}}", "")
+                    .Replace("{{if(", "").Replace(")if", "").Replace("endif}}", "");
+
+                // 匹配list数据，格式“Items.PropName”
+                var matchs = (Regex.Matches(innerText, "(?<={{).*?\\..*?(?=}})")
+                    .Cast<Match>().GroupBy(x => x.Value).Select(varGroup => varGroup.First().Value)).ToArray();
+                if (matchs.Length > 0)
+                {
+                    //var listKeys = matchs.Select(s => s.Split('.')[0]).Distinct().ToArray();
+                    //// TODO:
+                    //// not support > 2 list in same tr
+                    //if (listKeys.Length > 2)
+                    //    throw new NotSupportedException("MiniWord doesn't support more than 2 list in same row");
+                    //var listKey = listKeys[0];
+
+                    var listLevelKeys = matchs.Select(s => s.Substring(0, s.LastIndexOf('.'))).Distinct().ToArray();
+                    // TODO:
+                    // not support > 2 list in same tr
+                    if (listLevelKeys.Length > 2)
+                        throw new NotSupportedException("MiniWord doesn't support more than 2 list in same row");
+
+                    var tagObj = GetObjVal(tags, listLevelKeys[0]);
+
+                    if(tagObj == null) continue;
+
+                    if (tagObj is IEnumerable)
+                    {
+                        var attributeKey = matchs[0].Split('.')[0];
+                        var list = tagObj as IEnumerable;
+
+                        foreach (var item in list)
+                        {
+                            var dic = new Dictionary<string, object>(); //TODO: optimize
+
+
+                            var newTr = tr.CloneNode(true);
+                            if (item is IDictionary)
+                            {
+                                var es = (Dictionary<string, object>)item;
+                                foreach (var e in es)
+                                {
+                                    var dicKey = $"{listLevelKeys[0]}.{e.Key}";
+                                    dic.Add(dicKey, e.Value);
+                                }
+                            }
+                            // 支持Obj.A.B.C...
+                            else
+                            {
+                                var props = item.GetType().GetProperties();
+                                foreach (var p in props)
+                                {
+                                    var dicKey = $"{listLevelKeys[0]}.{p.Name}";
+                                    dic.Add(dicKey, p.GetValue(item));
+                                }
+                            }
+
+                            ReplaceIfStatements(newTr, tags: dic);
+
+                            ReplaceText(newTr, docx, tags: dic);
+                            //Fix #47 The table should be inserted at the template tag position instead of the last row
+                            if (table.Contains(tr))
+                            {
+                                table.InsertBefore(newTr, tr);
+                            }
+                            else
+                            {
+                                // If it is a nested table, temporarily append it to the end according to the original plan.
+                                table.Append(newTr);
+                            }
+                        }
+                        tr.Remove();
+                    }
+                    else
+                    {
+                        
+                    }
+                }
+                else
+                {
+                    var matchTxtProp = new Regex(@"(?<={{).*?\.?.*?(?=}})").Match(innerText);
+                    if(!matchTxtProp.Success) return;
+
+                    ReplaceText(tr, docx, tags);
+                }
+            }
         }
 
 
@@ -173,6 +203,7 @@
                 }
                 return null;
             }
+            // todo objSource = list
             var prop1 = objSource.GetType().GetProperty(propNames[0]);
             if (prop1 == null)
                 return null;
@@ -407,182 +438,315 @@
             return value;
         }
 
-        private static void ReplaceText(OpenXmlElement xmlElement, WordprocessingDocument docx, Dictionary<string, object> tags)
+        /// <summary>
+        /// 替换单个paragraph属性值
+        /// </summary>
+        /// <param name="p"></param>
+        /// <param name="docx"></param>
+        /// <param name="tags"></param>
+        private static void ReplaceText(Paragraph p, WordprocessingDocument docx, Dictionary<string, object> tags)
         {
-            var paragraphs = xmlElement.Descendants<Paragraph>().ToArray();
-            foreach (var p in paragraphs)
+            var runs = p.Descendants<Run>().ToArray();
+
+            foreach (var run in runs)
             {
-                var runs = p.Descendants<Run>().ToArray();
-
-                foreach (var run in runs)
+                var texts = run.Descendants<Text>().ToArray();
+                if (texts.Length == 0)
+                    continue;
+                foreach (Text t in texts)
                 {
-                    var texts = run.Descendants<Text>().ToArray();
-                    if (texts.Length == 0)
-                        continue;
-                    foreach (Text t in texts)
+                    foreach (var tag in tags)
                     {
-                        foreach (var tag in tags)
+                        // 完全匹配
+                        var isFullMatch = t.Text.Contains($"{{{{{tag.Key}}}}}");
+                        // 层级匹配，如{{A.B.C.D}}
+                        var partMatch = new Regex($".*{{{{({tag.Key}(\\.\\w+)+)}}}}.*").Match(t.Text);
+
+                        if (!isFullMatch && tag.Value is List<MiniWordForeach> forTags)
                         {
-                            // 完全匹配
-                            var isFullMatch = t.Text.Contains($"{{{{{tag.Key}}}}}");
-                            // 层级匹配，如{{A.B.C.D}}
-                            var partMatch = new Regex($".*{{{{({tag.Key}(\\.\\w+)+)}}}}.*").Match(t.Text);
-
-                            if (!isFullMatch && tag.Value is List<MiniWordForeach> forTags)
+                            if (forTags.Any(forTag => forTag.Value.Keys.Any(dictKey =>
                             {
-                                if (forTags.Any(forTag => forTag.Value.Keys.Any(dictKey =>
-                                {
-                                    var innerTag = "{{" + tag.Key + "." + dictKey + "}}";
-                                    return t.Text.Contains(innerTag);
-                                })))
-                                {
-                                    isFullMatch = true;
-                                }
-                            }
-
-                            if (isFullMatch || partMatch.Success)
+                                var innerTag = "{{" + tag.Key + "." + dictKey + "}}";
+                                return t.Text.Contains(innerTag);
+                            })))
                             {
-                                var key = isFullMatch ? tag.Key : partMatch.Groups[1].Value;
-                                var value = isFullMatch ? tag.Value : GetObjVal(tags, key);
-
-                                if (value is string[] || value is IList<string> || value is List<string>)
-                                {
-                                    var vs = value as IEnumerable;
-                                    var currentT = t;
-                                    var isFirst = true;
-                                    foreach (var v in vs)
-                                    {
-                                        var newT = t.CloneNode(true) as Text;
-                                        // todo
-                                        newT.Text = t.Text.Replace($"{{{{{key}}}}}", v?.ToString());
-                                        if (isFirst)
-                                            isFirst = false;
-                                        else
-                                            run.Append(new Break());
-                                        newT.Text = EvaluateIfStatement(newT.Text);
-                                        run.Append(newT);
-                                        currentT = newT;
-                                    }
-                                    t.Remove();
-                                }
-                                // todo 未验证嵌套对象的渲染
-                                else if (value is List<MiniWordForeach> vs)
-                                {
-                                    var currentT = t;
-                                    var generatedText = new Text();
-                                    currentT.Text = currentT.Text.Replace(@"{{foreach", "").Replace(@"endforeach}}", "");
-
-                                    var newTexts = new Dictionary<int, string>();
-                                    for (var i = 0; i < vs.Count; i++)
-                                    {
-                                        var newT = t.CloneNode(true) as Text;
-
-                                        foreach (var vv in vs[i].Value)
-                                        {
-                                            // todo tag,Key
-                                            newT.Text = newT.Text.Replace("{{" + tag.Key + "." + vv.Key + "}}", vv.Value.ToString());
-                                        }
-
-                                        newT.Text = EvaluateIfStatement(newT.Text);
-
-                                        if (!string.IsNullOrEmpty(newT.Text))
-                                            newTexts.Add(i, newT.Text);
-                                    }
-
-                                    for (var i = 0; i < newTexts.Count; i++)
-                                    {
-                                        var dict = newTexts.ElementAt(i);
-                                        generatedText.Text += dict.Value;
-
-                                        if (i != newTexts.Count - 1)
-                                        {
-                                            generatedText.Text += vs[dict.Key].Separator;
-                                        }
-                                    }
-
-                                    run.Append(generatedText);
-                                    t.Remove();
-                                }
-                                else if (IsHyperLink(value))
-                                {
-                                    AddHyperLink(docx, run, value);
-                                    t.Remove();
-                                }
-                                else if (value is MiniWordColorText || value is MiniWordColorText[])
-                                {
-                                    if (value is MiniWordColorText)
-                                    {
-                                        AddColorText(run, new[] { (MiniWordColorText)value });
-                                    }
-                                    else
-                                    {
-                                        AddColorText(run, (MiniWordColorText[])value);
-                                    }
-                                    t.Remove();
-                                }
-                                else if (value is MiniWordPicture)
-                                {
-                                    var pic = (MiniWordPicture)value;
-                                    byte[] l_Data = null;
-                                    if (pic.Path != null)
-                                    {
-                                        l_Data = File.ReadAllBytes(pic.Path);
-                                    }
-                                    if (pic.Bytes != null)
-                                    {
-                                        l_Data = pic.Bytes;
-                                    }
-
-                                    var mainPart = docx.MainDocumentPart;
-
-                                    var imagePart = mainPart.AddImagePart(pic.GetImagePartType);
-                                    using (var stream = new MemoryStream(l_Data))
-                                    {
-                                        imagePart.FeedData(stream);
-                                        AddPicture(run, mainPart.GetIdOfPart(imagePart), pic);
-
-                                    }
-                                    t.Remove();
-                                }
-                                else
-                                {
-                                    var newText = value is DateTime ? ((DateTime)value).ToString("yyyy-MM-dd HH:mm:ss") : value?.ToString();
-                                    t.Text = t.Text.Replace($"{{{{{key}}}}}", newText);
-                                }
+                                isFullMatch = true;
                             }
-
                         }
 
-                        t.Text = EvaluateIfStatement(t.Text);
-
-                        // add breakline
+                        if (isFullMatch || partMatch.Success)
                         {
-                            var newText = t.Text;
-                            var splits = Regex.Split(newText, "(<[a-zA-Z/].*?>|\n|\r\n)").Where(o => o != "\n" && o != "\r\n");
-                            var currentT = t;
-                            var isFirst = true;
-                            if (splits.Count() > 1)
+                            var key = isFullMatch ? tag.Key : partMatch.Groups[1].Value;
+                            var value = isFullMatch ? tag.Value : GetObjVal(tags, key);
+
+                            if (value is string[] || value is IList<string> || value is List<string>)
                             {
-                                foreach (var v in splits)
+                                var vs = value as IEnumerable;
+                                var currentT = t;
+                                var isFirst = true;
+                                foreach (var v in vs)
                                 {
                                     var newT = t.CloneNode(true) as Text;
-                                    newT.Text = v?.ToString();
+                                    // todo
+                                    newT.Text = t.Text.Replace($"{{{{{key}}}}}", v?.ToString());
                                     if (isFirst)
                                         isFirst = false;
                                     else
                                         run.Append(new Break());
+                                    newT.Text = EvaluateIfStatement(newT.Text);
                                     run.Append(newT);
                                     currentT = newT;
                                 }
                                 t.Remove();
                             }
+                            // todo 未验证嵌套对象的渲染
+                            else if (value is List<MiniWordForeach> vs)
+                            {
+                                var currentT = t;
+                                var generatedText = new Text();
+                                currentT.Text = currentT.Text.Replace(@"{{foreach", "").Replace(@"endforeach}}", "");
+
+                                var newTexts = new Dictionary<int, string>();
+                                for (var i = 0; i < vs.Count; i++)
+                                {
+                                    var newT = t.CloneNode(true) as Text;
+
+                                    foreach (var vv in vs[i].Value)
+                                    {
+                                        // todo tag,Key
+                                        newT.Text = newT.Text.Replace("{{" + tag.Key + "." + vv.Key + "}}", vv.Value.ToString());
+                                    }
+
+                                    newT.Text = EvaluateIfStatement(newT.Text);
+
+                                    if (!string.IsNullOrEmpty(newT.Text))
+                                        newTexts.Add(i, newT.Text);
+                                }
+
+                                for (var i = 0; i < newTexts.Count; i++)
+                                {
+                                    var dict = newTexts.ElementAt(i);
+                                    generatedText.Text += dict.Value;
+
+                                    if (i != newTexts.Count - 1)
+                                    {
+                                        generatedText.Text += vs[dict.Key].Separator;
+                                    }
+                                }
+
+                                run.Append(generatedText);
+                                t.Remove();
+                            }
+                            else if (IsHyperLink(value))
+                            {
+                                AddHyperLink(docx, run, value);
+                                t.Remove();
+                            }
+                            else if (value is MiniWordColorText || value is MiniWordColorText[])
+                            {
+                                if (value is MiniWordColorText)
+                                {
+                                    AddColorText(run, new[] { (MiniWordColorText)value });
+                                }
+                                else
+                                {
+                                    AddColorText(run, (MiniWordColorText[])value);
+                                }
+                                t.Remove();
+                            }
+                            else if (value is MiniWordPicture)
+                            {
+                                var pic = (MiniWordPicture)value;
+                                byte[] l_Data = null;
+                                if (pic.Path != null)
+                                {
+                                    l_Data = File.ReadAllBytes(pic.Path);
+                                }
+                                if (pic.Bytes != null)
+                                {
+                                    l_Data = pic.Bytes;
+                                }
+
+                                var mainPart = docx.MainDocumentPart;
+
+                                var imagePart = mainPart.AddImagePart(pic.GetImagePartType);
+                                using (var stream = new MemoryStream(l_Data))
+                                {
+                                    imagePart.FeedData(stream);
+                                    AddPicture(run, mainPart.GetIdOfPart(imagePart), pic);
+
+                                }
+                                t.Remove();
+                            }
+                            else
+                            {
+                                var newText = value is DateTime ? ((DateTime)value).ToString("yyyy-MM-dd HH:mm:ss") : value?.ToString();
+                                t.Text = t.Text.Replace($"{{{{{key}}}}}", newText);
+                            }
+                        }
+
+                    }
+
+                    t.Text = EvaluateIfStatement(t.Text);
+
+                    // add breakline
+                    {
+                        var newText = t.Text;
+                        var splits = Regex.Split(newText, "(<[a-zA-Z/].*?>|\n|\r\n)").Where(o => o != "\n" && o != "\r\n");
+                        var currentT = t;
+                        var isFirst = true;
+                        if (splits.Count() > 1)
+                        {
+                            foreach (var v in splits)
+                            {
+                                var newT = t.CloneNode(true) as Text;
+                                newT.Text = v?.ToString();
+                                if (isFirst)
+                                    isFirst = false;
+                                else
+                                    run.Append(new Break());
+                                run.Append(newT);
+                                currentT = newT;
+                            }
+                            t.Remove();
                         }
                     }
                 }
             }
         }
 
-        private static void ReplaceStatements(OpenXmlElement xmlElement, Dictionary<string, object> tags)
+        private static void ReplaceText(OpenXmlElement xmlElement, WordprocessingDocument docx, Dictionary<string, object> tags)
+        {
+            var paragraphs = xmlElement.Descendants<Paragraph>().ToArray();
+            foreach (var p in paragraphs)
+            {
+                ReplaceText(p,docx,tags);
+            }
+        }
+
+        /// <summary>
+        /// @foreach元素复制及填充
+        /// </summary>
+        /// <param name="xmlElement"></param>
+        private static void ReplaceForeachStatements(OpenXmlElement xmlElement,WordprocessingDocument docx,Dictionary<string,object> data)
+        {
+            // 1. 先获取Foreach的元素
+            var beginKey = "@foreach";
+            var endKey = "@endforeach";
+            var betweenEles = GetBetweenElements(xmlElement, beginKey, endKey, false);
+            if(betweenEles?.Any() != true) return;
+
+            var beginParagraph =
+                xmlElement.Descendants<Paragraph>().FirstOrDefault(p => p.InnerText.Contains(beginKey));
+            var endParagraph =
+                xmlElement.Descendants<Paragraph>().FirstOrDefault(p => p.InnerText.Contains(endKey));
+            // 获取需循环的数据key
+            var match = new Regex(@".*{{(\w+(\.\w+)*)}}.*").Match(beginParagraph.InnerText);
+            if(!match.Success) throw new Exception($"@Foreach循环未找到对应数据");
+            var foreachDataKey = match.Groups[1].Value;
+
+            // 删除关键字文本行
+            beginParagraph?.Remove();
+            endParagraph?.Remove();
+            // 循环体最后一个元素，用于新元素插入定位
+            var lastEleInLoop = betweenEles.LastOrDefault();
+            var copyLoopEles = betweenEles.Select(e => e.CloneNode(true)).ToList();
+            // 需要循环的数据
+            var foreachList = GetObjVal(data, foreachDataKey);
+            if (foreachList is IList list)
+            {
+                var loopEles = new List<OpenXmlElement>();
+                for (var i = 0; i < list.Count; i++)
+                {
+                    var item = list[i];
+                    var foreachDataDict = item.Obj2Dictionary();
+                    // 2. 渲染替换属性值{{}}，插入循环元素，再替换……
+                    // 2.1 替换属性值
+                    if (i == 0)
+                        loopEles = new List<OpenXmlElement>(betweenEles);
+                    foreach (var ele in loopEles)
+                    {
+                        if (ele is Table table)
+                            GenerateTable(table, docx, foreachDataDict);
+                        else if (ele is Paragraph p)
+                        {
+                            ReplaceText(p, docx, foreachDataDict);
+                        }
+                    }
+                    // 2.2 新增一个循环体元素
+                    if(list.Count - 1 > i)
+                    {
+                        loopEles.Clear();
+                        foreach (var ele in copyLoopEles)
+                        {
+                            var newEle = ele.CloneNode(true);
+                            xmlElement.InsertAfter(newEle, lastEleInLoop);
+                            lastEleInLoop = newEle;
+                            loopEles.Add(newEle);
+                        }
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// 将实体对象转为字典格式
+        /// </summary>
+        /// <param name="obj"></param>
+        /// <returns></returns>
+        private static Dictionary<string, object> Obj2Dictionary(this object obj)
+        {
+            var result = new Dictionary<string, object>();
+            if(obj == null) return null;
+            if (obj is IDictionary d)
+            {
+                foreach (object key in d.Keys)
+                {
+                    result.Add(key.ToString(), d[key]);
+                }
+            }
+            else
+            {
+                var props = obj.GetType().GetProperties();
+                foreach (var p in props)
+                {
+                    result.Add(p.Name,p.GetValue(obj));
+                }
+            }
+            return result;
+        }
+
+        /// <summary>
+        /// 获取关键词之间的元素
+        /// </summary>
+        /// <param name="sourceElement"></param>
+        /// <param name="beginKey"></param>
+        /// <param name="endKey"></param>
+        /// <param name="isCopyEle">是否克隆元素对象。true：返回克隆元素；false：返回原始元素</param>
+        /// <returns></returns>
+        private static List<OpenXmlElement> GetBetweenElements(OpenXmlElement sourceElement,string beginKey,string endKey,bool isCopyEle = true)
+        {
+            var beginParagraph =
+                sourceElement.Descendants<Paragraph>().FirstOrDefault(p => p.InnerText.Contains(beginKey));
+            var beginIndex = sourceElement.Elements().ToList().IndexOf(beginParagraph);
+            if (beginIndex < 0) return null;
+
+            var result = new List<OpenXmlElement>();
+            foreach (var element in sourceElement.Elements().Skip(beginIndex + 1))
+            {
+                result.Add(isCopyEle ? element.CloneNode(true) : element);
+                if (element is Paragraph p && p.InnerText.Contains(endKey))
+                {
+                    // 移除endKey的paragraph
+                    result.RemoveAt(result.Count - 1);
+                    return result;
+                }
+            }
+            return result;
+        }
+
+
+        private static void ReplaceIfStatements(OpenXmlElement xmlElement, Dictionary<string, object> tags)
         {
             var descendants = xmlElement.Descendants().ToList();
             var paragraphs = xmlElement.Descendants<Paragraph>().ToList();

--- a/src/MiniWord/MiniWord.Implment.cs
+++ b/src/MiniWord/MiniWord.Implment.cs
@@ -442,6 +442,9 @@
 
                             if (isFullMatch || partMatch.Success)
                             {
+                                var key = isFullMatch ? tag.Key : partMatch.Groups[1].Value;
+                                var value = isFullMatch ? tag.Value : GetObjVal(tags, key);
+
                                 if (tag.Value is string[] || tag.Value is IList<string> || tag.Value is List<string>)
                                 {
                                     var vs = tag.Value as IEnumerable;
@@ -498,9 +501,26 @@
                                     run.Append(generatedText);
                                     t.Remove();
                                 }
-                                else if (tag.Value is MiniWordPicture)
+                                else if (IsHyperLink(tag.Value))
                                 {
-                                    var pic = (MiniWordPicture)tag.Value;
+                                    AddHyperLink(docx, run, tag.Value);
+                                    t.Remove();
+                                }
+                                else if (tag.Value is MiniWordColorText || tag.Value is MiniWordColorText[])
+                                {
+                                    if (tag.Value is MiniWordColorText)
+                                    {
+                                        AddColorText(run, new[] { (MiniWordColorText)tag.Value });
+                                    }
+                                    else
+                                    {
+                                        AddColorText(run, (MiniWordColorText[])tag.Value);
+                                    }
+                                    t.Remove();
+                                }
+                                else if (value is MiniWordPicture)
+                                {
+                                    var pic = (MiniWordPicture)value;
                                     byte[] l_Data = null;
                                     if (pic.Path != null)
                                     {
@@ -522,29 +542,10 @@
                                     }
                                     t.Remove();
                                 }
-                                else if (IsHyperLink(tag.Value))
-                                {
-                                    AddHyperLink(docx, run, tag.Value);
-                                    t.Remove();
-                                }
-                                else if (tag.Value is MiniWordColorText || tag.Value is MiniWordColorText[])
-                                {
-                                    if (tag.Value is MiniWordColorText)
-                                    {
-                                        AddColorText(run, new[] { (MiniWordColorText)tag.Value });
-                                    }
-                                    else
-                                    {
-                                        AddColorText(run, (MiniWordColorText[])tag.Value);
-                                    }
-                                    t.Remove();
-                                }
                                 else
                                 {
-                                    var k = isFullMatch ? tag.Key : partMatch.Groups[1].Value;
-                                    var v = isFullMatch ? tag.Value : GetObjVal(tags, k);
-                                    var newText = tag.Value is DateTime ? ((DateTime)v).ToString("yyyy-MM-dd HH:mm:ss") : v?.ToString();
-                                    t.Text = t.Text.Replace($"{{{{{k}}}}}", newText);
+                                    var newText = tag.Value is DateTime ? ((DateTime)value).ToString("yyyy-MM-dd HH:mm:ss") : value?.ToString();
+                                    t.Text = t.Text.Replace($"{{{{{key}}}}}", newText);
                                 }
                             }
 


### PR DESCRIPTION
1. 支持嵌套对象的渲染
比如：`{{objA.objB.prop1}}`

2. 增加@foreach -@endforeach循环体
### 循环

 `@foreach` 和 `@endforeach` tags .

##### Example

```csharp
var value = new  
{
    LoopData = new List<object>()
    {
        new {
            Type="类型A",
            Items = new List<object>() {new {Name = "A-1"}, new {Name = "A-2"},}
        },
        new
        {
            Type="类型B",
            Items = new List<object>() {new {Name = "B-1"}, new {Name = "B-2"}, new {Name = "B-3"},}
        },
    }
};
MiniWord.SaveAsByTemplate(path, templatePath, value);
```

##### Template

![1](https://github.com/user-attachments/assets/5d32241d-3977-46e7-b3de-cae130e5a653)

##### Result

![2](https://github.com/user-attachments/assets/69daa15e-4864-483e-b132-d8e867b6d1d1)