### PR TITLE
Update MiniWord.Implment.cs

### DIFF
--- a/src/MiniWord/MiniWord.Implment.cs
+++ b/src/MiniWord/MiniWord.Implment.cs
@@ -236,7 +236,7 @@
             foreach (var text in texts)
             {
                 var clear = false;
-                if (text.InnerText.StartsWith("{"))
+                if (text.InnerText.TrimStart().StartsWith("{"))
                 {
                     needAppend = true;
                 }
@@ -245,7 +245,7 @@
                     sb.Append(text.InnerText);
                     pool.Add(text);
 
-                    var s = sb.ToString(); //TODO:
+                    var s = sb.ToString().TrimStart(); //TODO:
                                            // TODO: check tag exist
                                            // TODO: record tag text if without tag then system need to clear them
                                            // TODO: every {{tag}} one <t>for them</t> and add text before first text and copy first one and remove {{, tagname, }}


### PR DESCRIPTION
Fix when a Split Tag Text element Inner Text start with " {" instead of "{"