### PR TITLE
扩展：浮动图像，可配置图片浮动于文字上

### DIFF
--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -384,6 +384,17 @@ var value = new
 MiniWord.SaveAsByTemplate(path, templatePath, value);
 ```
 
+### 浮动图像
+
+可以通过MiniWordPicture扩展参数配置图片悬浮环绕在文字上或文字下
+`MiniWordPicture` 扩展参数。
+* WrappingType： MiniWordPictureWrappingType.Anchor 浮动图像
+* HorizontalPositionOffset: 设置图片相对于锚点的水平偏移量(以像素为单位)
+* VerticalPositionOffset：设置图片相对于锚点的垂直偏移量（以像素为单位）
+* BehindDoc: 控制图片是否显示在文档文字的后方
+* AllowOverlap: 控制图片是否允许与其他图片或对象重叠
+
+
 ## 例子
 
 

--- a/src/MiniWord/MiniWordPicture.cs
+++ b/src/MiniWord/MiniWordPicture.cs
@@ -5,10 +5,22 @@
     using System;
     using System.Collections.Generic;
 
+    public enum MiniWordPictureWrappingType
+    {
+        Inline,
+        Anchor
+    }
+    
     public class MiniWordPicture
     {
+        
+        public MiniWordPictureWrappingType WrappingType { get; set; } = MiniWordPictureWrappingType.Inline;
 
-
+        public bool BehindDoc { get; set; } = false;
+        public bool AllowOverlap { get; set; } = false;
+        public long HorizontalPositionOffset { get; set; } = 0;
+        public long VerticalPositionOffset { get; set; } = 0;
+        
         public string Path { get; set; }
         private string _extension;
         public string Extension


### PR DESCRIPTION
### 浮动图像

可以通过MiniWordPicture扩展参数配置图片悬浮环绕在文字上或文字下
`MiniWordPicture` 扩展参数。
* WrappingType： MiniWordPictureWrappingType.Anchor 浮动图像
* HorizontalPositionOffset: 设置图片相对于锚点的水平偏移量(以像素为单位)
* VerticalPositionOffset：设置图片相对于锚点的垂直偏移量（以像素为单位）
* BehindDoc: 控制图片是否显示在文档文字的后方
* AllowOverlap: 控制图片是否允许与其他图片或对象重叠

```C#
new MiniWordPicture() { Path = "image.png", Width = 160, Height = 160, WrappingType = MiniWordPictureWrappingType.Anchor, HorizontalPositionOffset = 400};
```