### PR TITLE
扩展渲染table支持单元格渲染，单元格模板{{}}只有一个的时list数据渲染每个单元格，超过一个时渲染行

### DIFF
--- a/src/MiniWord/MiniWord.Implment.cs
+++ b/src/MiniWord/MiniWord.Implment.cs
@@ -94,7 +94,8 @@ namespace MiniSoftware
             var trs = table.Elements<TableRow>().ToArray(); // remember toarray or system will loop OOM;
             var regexStr = "(?<={{).*?\\..*?(?=}})";
             //计算是否只有一个cell存在指令，如果超过1个则纵向渲染，否则横向渲染。
-            bool isHorizontal = table.Elements<TableRow>().SelectMany(s => s.Elements<TableCell>()).Count(w => Regex.Matches(w.InnerText, regexStr).Count > 0) <= 1;
+            var cellList = table.Elements<TableRow>().SelectMany(s => s.Elements<TableCell>()).ToList();
+            bool isHorizontal = cellList.Count > 1 && cellList.Count(w => Regex.Matches(w.InnerText, regexStr).Count > 0) <= 1;
 
             foreach (var tr in trs)
             {

--- a/src/MiniWord/MiniWord.Implment.cs
+++ b/src/MiniWord/MiniWord.Implment.cs
@@ -91,7 +91,7 @@ namespace MiniSoftware
         /// <exception cref="NotSupportedException"></exception>
         private static void GenerateTable(Table table, WordprocessingDocument docx, Dictionary<string, object> tags)
         {
-            var trs = table.Descendants<TableRow>().ToArray(); // remember toarray or system will loop OOM;
+            var trs = table.Elements<TableRow>().ToArray(); // remember toarray or system will loop OOM;
             var regexStr = "(?<={{).*?\\..*?(?=}})";
             //计算是否只有一个cell存在指令，如果超过1个则纵向渲染，否则横向渲染。
             bool isHorizontal = table.Elements<TableRow>().SelectMany(s => s.Elements<TableCell>()).Count(w => Regex.Matches(w.InnerText, regexStr).Count > 0) <= 1;


### PR DESCRIPTION
1.新增扩展
模板
<img width="1858" height="338" alt="image" src="https://github.com/user-attachments/assets/f2eddcb7-6887-43ea-976b-ca1f27ac1ef1" />


效果
<img width="1902" height="684" alt="image" src="https://github.com/user-attachments/assets/c85cfcb4-44a4-4260-8864-c39eab2708a4" />


2.修复bug
修复 当渲染table时使用 Descendants 会自动提取所有的tableRow,包括嵌套的tableRow,改用Elements，只提取子级的tr。
不修改效果是出现大量的无效tr
