### PR TITLE
html支持

### DIFF
--- a/src/MiniWord/MiniWord.Implment.cs
+++ b/src/MiniWord/MiniWord.Implment.cs
@@ -1,10 +1,11 @@
 namespace MiniSoftware
 {
     using DocumentFormat.OpenXml;
+    using DocumentFormat.OpenXml.Drawing.Charts;
     using DocumentFormat.OpenXml.Packaging;
     using DocumentFormat.OpenXml.Wordprocessing;
     using Extensions;
-    using Utility;
+    using HtmlToOpenXml;
     using System;
     using System.Collections;
     using System.Collections.Generic;
@@ -12,14 +13,14 @@ namespace MiniSoftware
     using System.Linq;
     using System.Text;
     using System.Text.RegularExpressions;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using System.Xml;
+    using System.Xml.Linq;
+    using Utility;
     using A = DocumentFormat.OpenXml.Drawing;
     using DW = DocumentFormat.OpenXml.Drawing.Wordprocessing;
     using PIC = DocumentFormat.OpenXml.Drawing.Pictures;
-    using System.Xml;
-    using System.Xml.Linq;
-    using DocumentFormat.OpenXml.Drawing.Charts;
-    using System.Threading.Tasks;
-    using System.Threading;
 
     public static partial class MiniWord
     {
@@ -653,6 +654,21 @@ namespace MiniSoftware
 
                                 t.Remove();
                             }
+                            else if (value is MiniWordHtml html)
+                            {
+                                AddHtmls(docx, run, new[] { html });
+                                t.Remove();
+                            }
+                            else if (value is MiniWordHtml[] htmls)
+                            {
+                                AddHtmls(docx, run, htmls);
+                                t.Remove();
+                            }
+                            else if (value is IEnumerable<MiniWordHtml> htmlList)
+                            {
+                                AddHtmls(docx, run, htmlList.ToArray());
+                                t.Remove();
+                            }
                             else
                             {
                                 var newText = value is DateTime
@@ -1175,5 +1191,58 @@ namespace MiniSoftware
                 return ms.ToArray();
             }
         }
+
+        #region html支持
+
+        /// <summary>
+        /// 填充htmls
+        /// </summary>
+        /// <param name="run"></param>
+        /// <param name="miniWordHtmls"></param>
+        private static void AddHtmls(WordprocessingDocument docx, Run run, MiniWordHtml[] miniWordHtmls)
+        {
+            //找到当前顶级段落（body）添加,html中的表格不能直接放在run或者段落里
+            Paragraph topPara = FindTopPara(run);
+            foreach (var miniWordHtml in miniWordHtmls)
+            {
+                try
+                {
+                    //实例化转换对象
+                    HtmlConverter converter = new HtmlConverter(docx.MainDocumentPart);
+                    //解析
+                    var paras = converter.Parse(miniWordHtml.HtmlText);
+                    //倒排插入（因为都是插入到标记位置后面所以需要倒排）
+                    for (var i = paras.Count - 1; i >= 0; i--)
+                    {
+                        var item = paras[i];
+                        topPara.Parent.InsertAfter(item, topPara);
+                    }
+                }
+                catch (Exception)
+                { }
+            }
+        }
+
+        /// <summary>
+        /// 找到当前顶级段落（body）添加
+        /// </summary>
+        /// <param name="run"></param>
+        /// <returns></returns>
+        private static Paragraph FindTopPara(Run run)
+        {
+            Paragraph result = null;
+            for (var pnode = run.Parent; pnode != null;)
+            {
+                if (pnode is Paragraph para && pnode.Parent != null && pnode.Parent is Body)
+                {
+                    result = para;
+                }
+                pnode = pnode.Parent;
+            }
+            return result;
+        }
+
+        #endregion
+
     }
 }

--- a/src/MiniWord/MiniWord.Implment.cs
+++ b/src/MiniWord/MiniWord.Implment.cs
@@ -659,14 +659,9 @@ namespace MiniSoftware
                                 AddHtmls(docx, run, new[] { html });
                                 t.Remove();
                             }
-                            else if (value is MiniWordHtml[] htmls)
-                            {
-                                AddHtmls(docx, run, htmls);
-                                t.Remove();
-                            }
                             else if (value is IEnumerable<MiniWordHtml> htmlList)
                             {
-                                AddHtmls(docx, run, htmlList.ToArray());
+                                AddHtmls(docx, run, htmlList);
                                 t.Remove();
                             }
                             else
@@ -1199,10 +1194,11 @@ namespace MiniSoftware
         /// </summary>
         /// <param name="run"></param>
         /// <param name="miniWordHtmls"></param>
-        private static void AddHtmls(WordprocessingDocument docx, Run run, MiniWordHtml[] miniWordHtmls)
+        private static void AddHtmls(WordprocessingDocument docx, Run run, IEnumerable<MiniWordHtml> miniWordHtmls)
         {
             //找到当前顶级段落（body）添加,html中的表格不能直接放在run或者段落里
             Paragraph topPara = FindTopPara(run);
+            if (topPara == null) return;
             foreach (var miniWordHtml in miniWordHtmls)
             {
                 try
@@ -1230,16 +1226,14 @@ namespace MiniSoftware
         /// <returns></returns>
         private static Paragraph FindTopPara(Run run)
         {
-            Paragraph result = null;
-            for (var pnode = run.Parent; pnode != null;)
+            for (var pnode = run.Parent; pnode != null; pnode = pnode.Parent)
             {
                 if (pnode is Paragraph para && pnode.Parent != null && pnode.Parent is Body)
                 {
-                    result = para;
+                    return para;
                 }
-                pnode = pnode.Parent;
             }
-            return result;
+            return null;
         }
 
         #endregion

--- a/src/MiniWord/MiniWord.csproj
+++ b/src/MiniWord/MiniWord.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFrameworks>net45;netstandard2.0;</TargetFrameworks>
+		<TargetFrameworks>net462;netstandard2.0;</TargetFrameworks>
 		<Version>0.9.1</Version>
 	</PropertyGroup>
 	<PropertyGroup>
@@ -33,6 +33,8 @@
 	</ItemGroup>
 	<ItemGroup>
 		<!--<PackageReference Include="DocumentFormat.OpenXml" Version="3.0.1" />-->
-		<PackageReference Include="DocumentFormat.OpenXml" Version="[3.1.1,4.0.0)" />
+		<PackageReference Include="DocumentFormat.OpenXml" Version="3.4.1" />
+		<PackageReference Include="HtmlToOpenXml.dll" Version="3.3.1" />
+		<PackageReference Include="System.Text.Encoding.CodePages" Version="10.0.3" />
 	</ItemGroup>
 </Project>

--- a/src/MiniWord/MiniWordHtml.cs
+++ b/src/MiniWord/MiniWordHtml.cs
@@ -1,0 +1,10 @@
+﻿namespace MiniSoftware
+{
+    /// <summary>
+    /// html参数对象
+    /// </summary>
+    public class MiniWordHtml
+    {
+        public string HtmlText { get; set; }
+    }
+}


### PR DESCRIPTION
1.因为HtmlToOpenXml依赖，调整项目依赖项为net462和netstandard2.0
2.项目添加依赖HtmlToOpenXml和codePages
3.新增类：MiniWordHtml
4.MiniWord.Implment.cs文件中，添加了html解析代码
5.调用示例：
new MiniWordHtml {
HtmlText = File.ReadAllText(@"TestData\sample2.html")
}
6.HtmlToOpenXml开源地址：https://github.com/onizet/html2openxml