### PR TITLE
Preserve spaces around template tags (#104)

### DIFF
--- a/src/MiniWord/MiniWord.Implment.cs
+++ b/src/MiniWord/MiniWord.Implment.cs
@@ -288,7 +288,8 @@ namespace MiniSoftware
                         {
                             var first = pool.First();
                             var newText = first.Clone() as Text;
-                            newText.Text = s;
+                            newText.Text = sb.ToString();
+                            newText.Space = SpaceProcessingModeValues.Preserve;
                             first.Parent.InsertBefore(newText, first);
                             foreach (var t in pool)
                             {

--- a/src/MiniWord/MiniWord.Implment.cs
+++ b/src/MiniWord/MiniWord.Implment.cs
@@ -264,7 +264,9 @@ namespace MiniSoftware
                     sb.Append(text.InnerText);
                     pool.Add(text);
 
-                    var s = sb.ToString().TrimStart(); //TODO:
+                    var rawText = sb.ToString();
+                    var s = rawText.TrimStart();
+
                     // TODO: check tag exist
                     // TODO: record tag text if without tag then system need to clear them
                     // TODO: every {{tag}} one <t>for them</t> and add text before first text and copy first one and remove {{, tagname, }}
@@ -288,8 +290,11 @@ namespace MiniSoftware
                         {
                             var first = pool.First();
                             var newText = first.Clone() as Text;
-                            newText.Text = sb.ToString();
-                            newText.Space = SpaceProcessingModeValues.Preserve;
+                            newText.Text = rawText;                            
+                            if (char.IsWhiteSpace(rawText[0]) || char.IsWhiteSpace(rawText[rawText.Length - 1]))
+                            {
+                                newText.Space = SpaceProcessingModeValues.Preserve;
+                            }
                             first.Parent.InsertBefore(newText, first);
                             foreach (var t in pool)
                             {


### PR DESCRIPTION
Fixes #104

## Problem
Spaces between template tags (or between tags and words) were dropped in the generated document. E.g. `From {{a}} to {{b}}` rendered as `From 11-may-2025to 11-may-2026`.

## Cause
In OOXML, leading/trailing whitespace in a `<w:t>` element is stripped unless the element has `xml:space="preserve"`. Text elements created during tag replacement were missing this attribute (which is also why non-breaking spaces were unaffected, as noted in the issue).

## Fix
Set `Space = SpaceProcessingModeValues.Preserve` on Text elements created during replacement.

## Testing
Reproduced the issue. After the fix, spaces are preserved correctly.